### PR TITLE
Better solution to setting cookies

### DIFF
--- a/src/routes/auth/auth.ts
+++ b/src/routes/auth/auth.ts
@@ -20,6 +20,13 @@ export const handleAuthRoute = async (request: Request, response: Response) => {
     }
 
     let SIWEObject = new SiweMessage(request.body.message);
+    if (!request.session.nonce) {
+      return sendResponse(response, request, {
+        message: 'No nonce found in session. Please request a nonce first.',
+        type: ResponseTypes.Error,
+        data: '',
+      }, HttpStatuses.UNPROCESSABLE);
+    }
     const { data: message } = await SIWEObject.verify({ signature: request.body.signature, nonce: request.session.nonce });
 
     request.session.auth = message;


### PR DESCRIPTION
NB Based on `refactor/create-colonies-on-ingestor`. Would ideally like to test on QA before deploying to production...

Because we have SSL termination, connections to the auth proxy, from the perspective of the auth proxy, are made via HTTP, so it would ordinarily refuse to set a secure cookie. 

This is what [trust proxy](https://expressjs.com/en/guide/behind-proxies.html) is designed to accommodate, which is set to `true`. Unfortunately, the `X-Forwarded-Proto` header it set to just `http` for reasons that are unclear.

Bogdan has added `proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;` to the NGINX ingress, which seems to add the protocol to the header, rather than set the header to that value, becoming `http, https`. Bogdan has tested turning SSL on and off on the cloudflare side, and seeing that the `https` switches to `http` as expected.

Unfortunately, the logic used to set the cookie or not expects to see only one protocol. So the fix is, the case where we see `https` in the last position of the header, we overwrite the whole header to just contain the one protocol.

EDIT: The jumping around with types and accommodating string arrays is because (I think... my TS is limited) the types for httpd do not include the `X-Forwarded-Proto` header, so it ends up with the default typing of `<string | string[]>`. Maybe someone more familiar with those arcane arts can get it picking it up as a `string`, which would allow some of this code to be removed.