### PR TITLE
Fix create/edit colony metadata handler using wrong ids for motions

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -40,7 +40,10 @@ const hasMutationPermissions = async (
        */
       case MutationOperations.CreateColonyMetadata:
       case MutationOperations.UpdateColonyMetadata: {
-        const { input: { id: colonyAddress } } = JSON.parse(variables);
+        const { input: { id } } = JSON.parse(variables);
+        const regex = /0x[a-fA-F0-9]{40}/;
+        const colonyAddress = id.match(regex);
+
         try {
           const data = await tryFetchGraphqlQuery(
             getColonyRole,

--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -8,6 +8,7 @@ import {
   getColonyRole,
   getColonyTokens,
 } from '~queries';
+import { getColonyAddressFromMutationId } from './utils';
 
 const hasMutationPermissions = async (
   operationName: string,
@@ -41,8 +42,7 @@ const hasMutationPermissions = async (
       case MutationOperations.CreateColonyMetadata:
       case MutationOperations.UpdateColonyMetadata: {
         const { input: { id } } = JSON.parse(variables);
-        const regex = /0x[a-fA-F0-9]{40}/;
-        const colonyAddress = id.match(regex);
+        const colonyAddress = getColonyAddressFromMutationId(id);
 
         try {
           const data = await tryFetchGraphqlQuery(

--- a/src/routes/graphql/utils.ts
+++ b/src/routes/graphql/utils.ts
@@ -1,0 +1,4 @@
+export const getColonyAddressFromMutationId = (id: string) => {
+  const regex = /0x[a-fA-F0-9]{40}/;
+  return id.match(regex);
+};


### PR DESCRIPTION
This PR is a fix for this issue: https://github.com/JoinColony/colonyCDapp/issues/1560

The pending colony metadata wasn't being stored when you created a motion because the auth proxy used the id of the pending colony metadata, which is not exactly the `colonyAddress` but `${colonyAddress}_motion-${motionTxHash}` so I've added a regex to extract and use only the first address that it founds on the `id`.

I've tested this by skipping the auth container on dev env startup, running the auth locally, and then making some edit colony details actions and motions.

CDapp counterpart: https://github.com/JoinColony/colonyCDapp/pull/1774