### PR TITLE
Allow expenditure metadata mutation, fix other metadata mutations checks

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -41,7 +41,7 @@ const hasMutationPermissions = async (
        * Colony
        */
       /**
-       * NOTE: Metadata can be created as part of the motion process, so we need to allow
+       * @NOTE: Metadata can be created as part of the motion process, so we need to allow
        * those mutations even for users with no permissions
        */
       case MutationOperations.CreateColonyMetadata: {
@@ -100,7 +100,7 @@ const hasMutationPermissions = async (
         }
       }
       /**
-       * NOTE: Metadata can be created as part of the motion process, so we need to allow
+       * @NOTE: Metadata can be created as part of the motion process, so we need to allow
        * those mutations even for users with no permissions
        */
       case MutationOperations.CreateDomainMetadata: {
@@ -166,6 +166,12 @@ const hasMutationPermissions = async (
           // silent
           return false;
         }
+      }
+      /**
+       * Expenditures
+       */
+      case MutationOperations.CreateExpenditureMetadata: {
+        return true;
       }
       /*
        * Always allow, it's just updating cache, anybody can trigger it

--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -3,11 +3,7 @@ import { ColonyRole } from '@colony/core';
 
 import { logger, detectOperation, tryFetchGraphqlQuery } from '~helpers';
 import { MutationOperations } from '~types';
-import {
-  getColonyAction,
-  getColonyRole,
-  getColonyTokens,
-} from '~queries';
+import { getColonyAction, getColonyRole, getColonyTokens } from '~queries';
 
 const hasMutationPermissions = async (
   operationName: string,
@@ -23,29 +19,42 @@ const hasMutationPermissions = async (
        */
       case MutationOperations.CreateUniqueUser:
       case MutationOperations.UpdateUserProfile: {
-        const { input: { id }} = JSON.parse(variables);
+        const {
+          input: { id },
+        } = JSON.parse(variables);
         return id?.toLowerCase() === userAddress?.toLowerCase();
       }
       case MutationOperations.CreateTransaction:
       case MutationOperations.UpdateTransaction: {
-        const { input: { from } } = JSON.parse(variables);
+        const {
+          input: { from },
+        } = JSON.parse(variables);
         return from?.toLowerCase() === userAddress?.toLowerCase();
       }
       case MutationOperations.CreateUserTokens: {
-        const { input: { userID } } = JSON.parse(variables);
+        const {
+          input: { userID },
+        } = JSON.parse(variables);
         return userID?.toLowerCase() === userAddress?.toLowerCase();
       }
       /*
        * Colony
        */
-      case MutationOperations.CreateColonyMetadata:
+      /**
+       * NOTE: Metadata can be created as part of the motion process, so we need to allow
+       * those mutations even for users with no permissions
+       */
+      case MutationOperations.CreateColonyMetadata: {
+        return true;
+      }
       case MutationOperations.UpdateColonyMetadata: {
-        const { input: { id: colonyAddress } } = JSON.parse(variables);
+        const {
+          input: { id: colonyAddress },
+        } = JSON.parse(variables);
         try {
-          const data = await tryFetchGraphqlQuery(
-            getColonyRole,
-            { combinedId: `${colonyAddress}_1_${userAddress}_roles` },
-          );
+          const data = await tryFetchGraphqlQuery(getColonyRole, {
+            combinedId: `${colonyAddress}_1_${userAddress}_roles`,
+          });
           return !!data[`role_${ColonyRole.Root}`];
         } catch (error) {
           // silent
@@ -53,58 +62,68 @@ const hasMutationPermissions = async (
         }
       }
       case MutationOperations.CreateColonyContributor: {
-        const { input: { contributorAddress } } = JSON.parse(variables);
+        const {
+          input: { contributorAddress },
+        } = JSON.parse(variables);
         return contributorAddress?.toLowerCase() === userAddress?.toLowerCase();
       }
       case MutationOperations.UpdateColonyContributor: {
-        const { input: { id: combinedContributorId } } = JSON.parse(variables);
+        const {
+          input: { id: combinedContributorId },
+        } = JSON.parse(variables);
         const [, contributorWalletAddress] = combinedContributorId.split('_');
-        return contributorWalletAddress?.toLowerCase() === userAddress?.toLowerCase();
+        return (
+          contributorWalletAddress?.toLowerCase() === userAddress?.toLowerCase()
+        );
       }
       case MutationOperations.CreateColonyEtherealMetadata: {
-        const { input: { initiatorAddress } } = JSON.parse(variables);
+        const {
+          input: { initiatorAddress },
+        } = JSON.parse(variables);
         return initiatorAddress?.toLowerCase() === userAddress?.toLowerCase();
       }
       /*
        * Domains
        */
       case MutationOperations.CreateDomain: {
-        const { input: { colonyId: colonyAddress } } = JSON.parse(variables);
+        const {
+          input: { colonyId: colonyAddress },
+        } = JSON.parse(variables);
         try {
-          const data = await tryFetchGraphqlQuery(
-            getColonyRole,
-            { combinedId: `${colonyAddress}_1_${userAddress}_roles` },
-          );
+          const data = await tryFetchGraphqlQuery(getColonyRole, {
+            combinedId: `${colonyAddress}_1_${userAddress}_roles`,
+          });
           return !!data[`role_${ColonyRole.Architecture}`];
         } catch (error) {
           // silent
           return false;
         }
       }
-      case MutationOperations.CreateDomainMetadata:
+      /**
+       * NOTE: Metadata can be created as part of the motion process, so we need to allow
+       * those mutations even for users with no permissions
+       */
+      case MutationOperations.CreateDomainMetadata: {
+        return true;
+      }
       case MutationOperations.UpdateDomainMetadata: {
-        const { input: { id: combinedId } } = JSON.parse(variables);
-        try {
-          const [colonyAddress] = combinedId.split('_');
-          const data = await tryFetchGraphqlQuery(
-            getColonyRole,
-            { combinedId: `${colonyAddress}_1_${userAddress}_roles` },
-          );
-          return !!data[`role_${ColonyRole.Architecture}`];
-        } catch (error) {
-          // silent
-          return false;
-        }
+        return true;
       }
       /*
        * Actions, Mutations
        */
       case MutationOperations.CreateAnnotation:
       case MutationOperations.CreateColonyActionMetadata: {
-        const { input: { id: actionId } } = JSON.parse(variables);
+        const {
+          input: { id: actionId },
+        } = JSON.parse(variables);
         try {
-          const data = await tryFetchGraphqlQuery(getColonyAction, { actionId });
-          return data.initiatorAddress?.toLowerCase() === userAddress?.toLowerCase();
+          const data = await tryFetchGraphqlQuery(getColonyAction, {
+            actionId,
+          });
+          return (
+            data.initiatorAddress?.toLowerCase() === userAddress?.toLowerCase()
+          );
         } catch (error) {
           // silent
           return false;
@@ -114,12 +133,13 @@ const hasMutationPermissions = async (
        * Tokens
        */
       case MutationOperations.CreateColonyTokens: {
-        const { input: { colonyID: colonyAddress } } = JSON.parse(variables);
+        const {
+          input: { colonyID: colonyAddress },
+        } = JSON.parse(variables);
         try {
-          const data = await tryFetchGraphqlQuery(
-            getColonyRole,
-            { combinedId: `${colonyAddress}_1_${userAddress}_roles` },
-          );
+          const data = await tryFetchGraphqlQuery(getColonyRole, {
+            combinedId: `${colonyAddress}_1_${userAddress}_roles`,
+          });
           return !!data[`role_${ColonyRole.Root}`];
         } catch (error) {
           // silent
@@ -127,15 +147,18 @@ const hasMutationPermissions = async (
         }
       }
       case MutationOperations.DeleteColonyTokens: {
-        const { input: { id: tokenColonyId } } = JSON.parse(variables);
+        const {
+          input: { id: tokenColonyId },
+        } = JSON.parse(variables);
         try {
-          const tokenData = await tryFetchGraphqlQuery(getColonyTokens, { tokenColonyId });
+          const tokenData = await tryFetchGraphqlQuery(getColonyTokens, {
+            tokenColonyId,
+          });
 
           if (tokenData?.colonyID) {
-            const data = await tryFetchGraphqlQuery(
-              getColonyRole,
-              { combinedId: `${tokenData.colonyID}_1_${userAddress}_roles` },
-            );
+            const data = await tryFetchGraphqlQuery(getColonyRole, {
+              combinedId: `${tokenData.colonyID}_1_${userAddress}_roles`,
+            });
             return !!data[`role_${ColonyRole.Root}`];
           }
           return false;
@@ -152,19 +175,22 @@ const hasMutationPermissions = async (
       case MutationOperations.GetTokenFromEverywhere:
       case MutationOperations.UpdateContributorsWithReputation: {
         return true;
-      };
+      }
       default: {
         return false;
       }
     }
   } catch (error) {
-    logger(`Error when attempting to check if user ${userAddress} can execute mutation ${operationName} with variables ${variables}`, error);
+    logger(
+      `Error when attempting to check if user ${userAddress} can execute mutation ${operationName} with variables ${variables}`,
+      error,
+    );
     /*
      * If anything fails just prevent the mutation from executing
      */
     return false;
   }
-}
+};
 
 const addressCanExecuteMutation = async (
   request: Request,
@@ -177,10 +203,8 @@ const addressCanExecuteMutation = async (
     }
     const canExecuteAllOperations = await Promise.all(
       operations.map(
-        async (operationName) => await hasMutationPermissions(
-          operationName,
-          request,
-        ),
+        async (operationName) =>
+          await hasMutationPermissions(operationName, request),
       ),
     );
     return canExecuteAllOperations.every((canExecute) => canExecute);

--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -40,13 +40,6 @@ const hasMutationPermissions = async (
       /*
        * Colony
        */
-      /**
-       * @NOTE: Metadata can be created as part of the motion process, so we need to allow
-       * those mutations even for users with no permissions
-       */
-      case MutationOperations.CreateColonyMetadata: {
-        return true;
-      }
       case MutationOperations.UpdateColonyMetadata: {
         const {
           input: { id: colonyAddress },
@@ -98,13 +91,6 @@ const hasMutationPermissions = async (
           // silent
           return false;
         }
-      }
-      /**
-       * @NOTE: Metadata can be created as part of the motion process, so we need to allow
-       * those mutations even for users with no permissions
-       */
-      case MutationOperations.CreateDomainMetadata: {
-        return true;
       }
       case MutationOperations.UpdateDomainMetadata: {
         return true;
@@ -173,6 +159,12 @@ const hasMutationPermissions = async (
       case MutationOperations.CreateExpenditureMetadata: {
         return true;
       }
+      /**
+       * Metadata can be created as part of the motion process, so we need to allow
+       * those mutations even for users with no permissions
+       */
+      case MutationOperations.CreateColonyMetadata:
+      case MutationOperations.CreateDomainMetadata:
       /*
        * Always allow, it's just updating cache, anybody can trigger it
        */

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,10 @@ export enum MutationOperations {
   GetTokenFromEverywhere = 'getTokenFromEverywhere',
   CreateColonyTokens = 'createColonyTokens',
   DeleteColonyTokens = 'deleteColonyTokens',
+  /*
+   * Expenditures
+   */
+  CreateExpenditureMetadata = 'createExpenditureMetadata',
 }
 
 export enum HttpStatuses {


### PR DESCRIPTION
This PR allows calls to `createExpenditureMetadata` (somewhat risky, as the ID is `colonyAddress_nativeId`, so pretty much sequential, but I'm talking to Alex on how we can change that) and also fixes logic with other create metadata mutations checks. I realised users creating pending metadata will most likely not have permissions (as they're going through a motion) so I removed the checks from those.