### PR TITLE
Feat: Allow RemoveMemberFromColonyWhitelist mutation

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -95,6 +95,15 @@ const hasMutationPermissions = async (
       case MutationOperations.UpdateDomainMetadata: {
         return true;
       }
+      case MutationOperations.RemoveMemberFromColonyWhitelist: {
+        const {
+          input: { userAddress: userAddressToRemove },
+        } = JSON.parse(variables);
+        // Ensure that a user can only remove themselves from the whitelist, not another user
+        return (
+          userAddressToRemove?.toLowerCase() === userAddress?.toLowerCase()
+        );
+      }
       /*
        * Actions, Mutations
        */

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export enum MutationOperations {
   UpdateColonyContributor = 'updateColonyContributor',
   UpdateContributorsWithReputation = 'updateContributorsWithReputation',
   CreateColonyEtherealMetadata = 'createColonyEtherealMetadata',
+  RemoveMemberFromColonyWhitelist = "removeMemberFromColonyWhitelist",
   /*
    * Domains
    */


### PR DESCRIPTION
Related to: https://github.com/JoinColony/colonyCDapp/pull/1999

Allows 'RemoveMemberFromColonyWhitelist' mutation, only when the userAddress to remove from the whitelist matches the authenticated userAddress.