### PR TITLE
Maintenance: Remove Colony whitelist references

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -95,15 +95,6 @@ const hasMutationPermissions = async (
       case MutationOperations.UpdateDomainMetadata: {
         return true;
       }
-      case MutationOperations.RemoveMemberFromColonyWhitelist: {
-        const {
-          input: { userAddress: userAddressToRemove },
-        } = JSON.parse(variables);
-        // Ensure that a user can only remove themselves from the whitelist, not another user
-        return (
-          userAddressToRemove?.toLowerCase() === userAddress?.toLowerCase()
-        );
-      }
       /*
        * Actions, Mutations
        */

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export enum MutationOperations {
   UpdateColonyContributor = 'updateColonyContributor',
   UpdateContributorsWithReputation = 'updateContributorsWithReputation',
   CreateColonyEtherealMetadata = 'createColonyEtherealMetadata',
-  RemoveMemberFromColonyWhitelist = 'removeMemberFromColonyWhitelist',
   /*
    * Domains
    */


### PR DESCRIPTION
## Description

This is done as part of [colonyCDapp#2450](https://github.com/JoinColony/colonyCDapp/pull/2450): fix: Add addresses to a Colony even if they are not members.

All references to a Colony whitelist have been removed from that repo so this PR is a clean up operation to remove a redundant case statement for the `RemoveMemberFromColonyWhitelist` operation.