### PR TITLE
Fix: Ensure graphql results are there before destructuring

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -163,13 +163,16 @@ export const tryFetchGraphqlQuery = async (
 ) => {
   let currentTry = 0;
   while (true) {
-    const { data } = await graphqlRequest(queryOrMutation, variables);
+    const result = await graphqlRequest(queryOrMutation, variables);
 
     /*
      * @NOTE That this limits to only fetching one operation at a time
      */
-    if (data[Object.keys(data)[0]]) {
-      return data[Object.keys(data)[0]];
+    if (result) {
+      const { data } = result;
+      if (data[Object.keys(data)[0]]) {
+        return data[Object.keys(data)[0]];
+      }
     }
 
     if (currentTry < maxRetries) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -168,7 +168,7 @@ export const tryFetchGraphqlQuery = async (
     /*
      * @NOTE That this limits to only fetching one operation at a time
      */
-    if (result) {
+    if (result?.data) {
       const { data } = result;
       if (data[Object.keys(data)[0]]) {
         return data[Object.keys(data)[0]];


### PR DESCRIPTION
Ensure that the result of a graphql request is present before destructuring the object. Sometimes the graphql request can fail due to unforseen circumstances (in the case that made this issue be raised it was a race condition when creating action metadata). This was causing an uncaught error which would then result in the retry not happening and mutations being shown as forbidden.

Not the easiest to test, but I ran the auth proxy locally (npm run dev), tried creating actions, and watched for an error that is logged at the end of the graphql attempt here:

<img width="682" alt="Screenshot 2024-07-31 at 13 43 35" src="https://github.com/user-attachments/assets/94396881-9d8b-4d69-a677-aa9e71e7606f">

This means that the graphql call failed, the result will be null, and therefore shouldn't be destructured. On master, this is where the error was breaking things, so the idea here is that to test it we can look for this console log, and when it happens, see that it retries and the mutation is still allowed, and action metadata can be created. You may have to keep retrying to make actions a few times though before you see this error, since it is a race condition. I've attached a video of my testing to try and make this more clear:

https://github.com/user-attachments/assets/3691e0f8-3a15-4d7d-9e1e-f1f51a37ff7f

