### PR TITLE
Feat/add initialize user mutation

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -31,6 +31,12 @@ const hasMutationPermissions = async (
         } = JSON.parse(variables);
         return userAddress && id && id.toLowerCase() === userAddress.toLowerCase();
       }
+      case MutationOperations.InitializeUser: {
+        const {
+          input: { userAddress: givenUserAddress },
+        } = JSON.parse(variables);
+        return userAddress && givenUserAddress && givenUserAddress.toLowerCase() === userAddress.toLowerCase();
+      }
       case MutationOperations.CreateTransaction: {
         const {
           input: { from },

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export enum MutationOperations {
   CreateTransaction = 'createTransaction',
   UpdateTransaction = 'updateTransaction',
   CreateUserTokens = 'createUserTokens',
+  InitializeUser = 'initializeUser',
   /*
    * Colony
    */


### PR DESCRIPTION
Note: this PR is based on #26.

This PR allows for the `initializeUser` mutation to be passed through, as long as the user is logged in with their userId and it matches to the one given in the query.

See also https://github.com/JoinColony/colonyCDapp/pull/3015 for more details