### PR TITLE
Add initialize user mutation

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -31,6 +31,10 @@ const hasMutationPermissions = async (
         } = JSON.parse(variables);
         return userAddress && id && id.toLowerCase() === userAddress.toLowerCase();
       }
+      case MutationOperations.InitializeUser: {
+        // This is always allowed as the actual check is happening in the lambda
+        return true;
+      }
       case MutationOperations.CreateTransaction: {
         const {
           input: { from },

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export enum MutationOperations {
   CreateTransaction = 'createTransaction',
   UpdateTransaction = 'updateTransaction',
   CreateUserTokens = 'createUserTokens',
+  InitializeUser = 'initializeUser',
   /*
    * Colony
    */


### PR DESCRIPTION
This PR allows for the initializeUser mutation to be passed through. The actual check happens in the lambda (it will just use the authenticated `userAddress`).

See also https://github.com/JoinColony/colonyCDapp/pull/3015 for more details

This supersedes #25 which I closed prematurely.