### PR TITLE
[Notifications] feat: rework user notifications userAddress lookup

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -37,7 +37,9 @@ const hasMutationPermissions = async (
         return true;
       }
       case MutationOperations.UpdateUserNotificationsData: {
-        const { userAddress: mutationUserAddress } = JSON.parse(variables);
+        const {
+          input: { userAddress: mutationUserAddress },
+        } = JSON.parse(variables);
 
         return (
           userAddress?.toLowerCase() === mutationUserAddress?.toLowerCase()


### PR DESCRIPTION
I changed the input so now `userAddress` is nested instead of top level
part of [this PR](https://github.com/JoinColony/colonyCDapp/pull/3289)