### PR TITLE
Feat: Bypass CreateProxyToken mutation

### DIFF
--- a/src/routes/graphql/mutations.ts
+++ b/src/routes/graphql/mutations.ts
@@ -271,6 +271,12 @@ const hasMutationPermissions = async (
       case MutationOperations.BridgeUpdateBankAccount: {
         return true;
       }
+      /*
+       * Once a proxy colony gets deployed, we need to allow the creation of a related token on the proxy chain
+       */
+      case MutationOperations.CreateProxyToken: {
+        return true;
+      }
       default: {
         return false;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export enum MutationOperations {
   GetTokenFromEverywhere = 'getTokenFromEverywhere',
   CreateColonyTokens = 'createColonyTokens',
   DeleteColonyTokens = 'deleteColonyTokens',
+  CreateProxyToken = 'createProxyToken',
   /*
    * Expenditures
    */


### PR DESCRIPTION
The purpose of this PR is to allow the `createProxyToken` mutations

[CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/4186)

#### TODO
- [ ] Need to align if we want to perform any checks on the user performing this mutation